### PR TITLE
Explore returning Dataframes Straight from Prom with Different Codec

### DIFF
--- a/web/api/v1/api.go
+++ b/web/api/v1/api.go
@@ -277,7 +277,7 @@ func NewAPI(
 		remoteReadHandler: remote.NewReadHandler(logger, registerer, q, configFunc, remoteReadSampleLimit, remoteReadConcurrencyLimit, remoteReadMaxBytesInFrame),
 	}
 
-	a.InstallCodec(JSONCodec{})
+	a.InstallCodec(JSONGDFCodec{})
 
 	if statsRenderer != nil {
 		a.statsRenderer = statsRenderer
@@ -463,13 +463,9 @@ func (api *API) query(r *http.Request) (result apiFuncResult) {
 	if sr == nil {
 		sr = defaultStatsRenderer
 	}
-	qs := sr(ctx, qry.Stats(), r.FormValue("stats"))
+	//qs := sr(ctx, qry.Stats(), r.FormValue("stats"))
 
-	return apiFuncResult{&QueryData{
-		ResultType: res.Value.Type(),
-		Result:     res.Value,
-		Stats:      qs,
-	}, nil, res.Warnings, qry.Close}
+	return apiFuncResult{res, nil, res.Warnings, qry.Close}
 }
 
 func (api *API) formatQuery(r *http.Request) (result apiFuncResult) {
@@ -565,13 +561,9 @@ func (api *API) queryRange(r *http.Request) (result apiFuncResult) {
 	if sr == nil {
 		sr = defaultStatsRenderer
 	}
-	qs := sr(ctx, qry.Stats(), r.FormValue("stats"))
+	//qs := sr(ctx, qry.Stats(), r.FormValue("stats"))
 
-	return apiFuncResult{&QueryData{
-		ResultType: res.Value.Type(),
-		Result:     res.Value,
-		Stats:      qs,
-	}, nil, res.Warnings, qry.Close}
+	return apiFuncResult{res, nil, res.Warnings, qry.Close}
 }
 
 func (api *API) queryExemplars(r *http.Request) apiFuncResult {

--- a/web/api/v1/json_codec_test.go
+++ b/web/api/v1/json_codec_test.go
@@ -28,7 +28,7 @@ func TestJsonCodec_Encode(t *testing.T) {
 		{
 			response: promql.Matrix{
 				promql.Series{
-					Floats: []promql.FPoint{{F: 1, T: 1000}},
+					Floats: []promql.FPoint{{F: 1, T: 1000}, {F: 6.2, T: 2000}},
 					Metric: labels.FromStrings("__name__", "foo"),
 				},
 			},

--- a/web/api/v1/json_codec_test.go
+++ b/web/api/v1/json_codec_test.go
@@ -14,14 +14,10 @@
 package v1
 
 import (
-	"math"
 	"testing"
 
-	"github.com/prometheus/prometheus/model/exemplar"
-	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 )
 
 func TestJsonCodec_Encode(t *testing.T) {
@@ -30,137 +26,134 @@ func TestJsonCodec_Encode(t *testing.T) {
 		expected string
 	}{
 		{
-			response: &QueryData{
-				ResultType: parser.ValueTypeMatrix,
-				Result: promql.Matrix{
-					promql.Series{
-						Floats: []promql.FPoint{{F: 1, T: 1000}},
-						Metric: labels.FromStrings("__name__", "foo"),
-					},
+			response: promql.Matrix{
+				promql.Series{
+					Floats: []promql.FPoint{{F: 1, T: 1000}},
+					Metric: labels.FromStrings("__name__", "foo"),
 				},
 			},
 			expected: `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"foo"},"values":[[1,"1"]]}]}}`,
 		},
-		{
-			response: &QueryData{
-				ResultType: parser.ValueTypeMatrix,
-				Result: promql.Matrix{
-					promql.Series{
-						Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{
-							Schema:        2,
-							ZeroThreshold: 0.001,
-							ZeroCount:     12,
-							Count:         10,
-							Sum:           20,
-							PositiveSpans: []histogram.Span{
-								{Offset: 3, Length: 2},
-								{Offset: 1, Length: 3},
-							},
-							NegativeSpans: []histogram.Span{
-								{Offset: 2, Length: 2},
-							},
-							PositiveBuckets: []float64{1, 2, 2, 1, 1},
-							NegativeBuckets: []float64{2, 1},
-						}, T: 1000}},
-						Metric: labels.FromStrings("__name__", "foo"),
-					},
-				},
-			},
-			expected: `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"foo"},"histograms":[[1,{"count":"10","sum":"20","buckets":[[1,"-1.6817928305074288","-1.414213562373095","1"],[1,"-1.414213562373095","-1.189207115002721","2"],[3,"-0.001","0.001","12"],[0,"1.414213562373095","1.6817928305074288","1"],[0,"1.6817928305074288","2","2"],[0,"2.378414230005442","2.82842712474619","2"],[0,"2.82842712474619","3.3635856610148576","1"],[0,"3.3635856610148576","4","1"]]}]]}]}}`,
-		},
-		{
-			response: promql.FPoint{F: 0, T: 0},
-			expected: `{"status":"success","data":[0,"0"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 1},
-			expected: `{"status":"success","data":[0.001,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 10},
-			expected: `{"status":"success","data":[0.010,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 100},
-			expected: `{"status":"success","data":[0.100,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 1001},
-			expected: `{"status":"success","data":[1.001,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 1010},
-			expected: `{"status":"success","data":[1.010,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 1100},
-			expected: `{"status":"success","data":[1.100,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: 12345678123456555},
-			expected: `{"status":"success","data":[12345678123456.555,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: 20, T: -1},
-			expected: `{"status":"success","data":[-0.001,"20"]}`,
-		},
-		{
-			response: promql.FPoint{F: math.NaN(), T: 0},
-			expected: `{"status":"success","data":[0,"NaN"]}`,
-		},
-		{
-			response: promql.FPoint{F: math.Inf(1), T: 0},
-			expected: `{"status":"success","data":[0,"+Inf"]}`,
-		},
-		{
-			response: promql.FPoint{F: math.Inf(-1), T: 0},
-			expected: `{"status":"success","data":[0,"-Inf"]}`,
-		},
-		{
-			response: promql.FPoint{F: 1.2345678e6, T: 0},
-			expected: `{"status":"success","data":[0,"1234567.8"]}`,
-		},
-		{
-			response: promql.FPoint{F: 1.2345678e-6, T: 0},
-			expected: `{"status":"success","data":[0,"0.0000012345678"]}`,
-		},
-		{
-			response: promql.FPoint{F: 1.2345678e-67, T: 0},
-			expected: `{"status":"success","data":[0,"1.2345678e-67"]}`,
-		},
-		{
-			response: []exemplar.QueryResult{
-				{
-					SeriesLabels: labels.FromStrings("foo", "bar"),
-					Exemplars: []exemplar.Exemplar{
-						{
-							Labels: labels.FromStrings("trace_id", "abc"),
-							Value:  100.123,
-							Ts:     1234,
-						},
-					},
-				},
-			},
-			expected: `{"status":"success","data":[{"seriesLabels":{"foo":"bar"},"exemplars":[{"labels":{"trace_id":"abc"},"value":"100.123","timestamp":1.234}]}]}`,
-		},
-		{
-			response: []exemplar.QueryResult{
-				{
-					SeriesLabels: labels.FromStrings("foo", "bar"),
-					Exemplars: []exemplar.Exemplar{
-						{
-							Labels: labels.FromStrings("trace_id", "abc"),
-							Value:  math.Inf(1),
-							Ts:     1234,
-						},
-					},
-				},
-			},
-			expected: `{"status":"success","data":[{"seriesLabels":{"foo":"bar"},"exemplars":[{"labels":{"trace_id":"abc"},"value":"+Inf","timestamp":1.234}]}]}`,
-		},
+		// {
+		// 	response: &QueryData{
+		// 		ResultType: parser.ValueTypeMatrix,
+		// 		Result: promql.Matrix{
+		// 			promql.Series{
+		// 				Histograms: []promql.HPoint{{H: &histogram.FloatHistogram{
+		// 					Schema:        2,
+		// 					ZeroThreshold: 0.001,
+		// 					ZeroCount:     12,
+		// 					Count:         10,
+		// 					Sum:           20,
+		// 					PositiveSpans: []histogram.Span{
+		// 						{Offset: 3, Length: 2},
+		// 						{Offset: 1, Length: 3},
+		// 					},
+		// 					NegativeSpans: []histogram.Span{
+		// 						{Offset: 2, Length: 2},
+		// 					},
+		// 					PositiveBuckets: []float64{1, 2, 2, 1, 1},
+		// 					NegativeBuckets: []float64{2, 1},
+		// 				}, T: 1000}},
+		// 				Metric: labels.FromStrings("__name__", "foo"),
+		// 			},
+		// 		},
+		// 	},
+		// 	expected: `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"foo"},"histograms":[[1,{"count":"10","sum":"20","buckets":[[1,"-1.6817928305074288","-1.414213562373095","1"],[1,"-1.414213562373095","-1.189207115002721","2"],[3,"-0.001","0.001","12"],[0,"1.414213562373095","1.6817928305074288","1"],[0,"1.6817928305074288","2","2"],[0,"2.378414230005442","2.82842712474619","2"],[0,"2.82842712474619","3.3635856610148576","1"],[0,"3.3635856610148576","4","1"]]}]]}]}}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 0, T: 0},
+		// 	expected: `{"status":"success","data":[0,"0"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 1},
+		// 	expected: `{"status":"success","data":[0.001,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 10},
+		// 	expected: `{"status":"success","data":[0.010,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 100},
+		// 	expected: `{"status":"success","data":[0.100,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 1001},
+		// 	expected: `{"status":"success","data":[1.001,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 1010},
+		// 	expected: `{"status":"success","data":[1.010,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 1100},
+		// 	expected: `{"status":"success","data":[1.100,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: 12345678123456555},
+		// 	expected: `{"status":"success","data":[12345678123456.555,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 20, T: -1},
+		// 	expected: `{"status":"success","data":[-0.001,"20"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: math.NaN(), T: 0},
+		// 	expected: `{"status":"success","data":[0,"NaN"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: math.Inf(1), T: 0},
+		// 	expected: `{"status":"success","data":[0,"+Inf"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: math.Inf(-1), T: 0},
+		// 	expected: `{"status":"success","data":[0,"-Inf"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 1.2345678e6, T: 0},
+		// 	expected: `{"status":"success","data":[0,"1234567.8"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 1.2345678e-6, T: 0},
+		// 	expected: `{"status":"success","data":[0,"0.0000012345678"]}`,
+		// },
+		// {
+		// 	response: promql.FPoint{F: 1.2345678e-67, T: 0},
+		// 	expected: `{"status":"success","data":[0,"1.2345678e-67"]}`,
+		// },
+		// {
+		// 	response: []exemplar.QueryResult{
+		// 		{
+		// 			SeriesLabels: labels.FromStrings("foo", "bar"),
+		// 			Exemplars: []exemplar.Exemplar{
+		// 				{
+		// 					Labels: labels.FromStrings("trace_id", "abc"),
+		// 					Value:  100.123,
+		// 					Ts:     1234,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	expected: `{"status":"success","data":[{"seriesLabels":{"foo":"bar"},"exemplars":[{"labels":{"trace_id":"abc"},"value":"100.123","timestamp":1.234}]}]}`,
+		// },
+		// {
+		// 	response: []exemplar.QueryResult{
+		// 		{
+		// 			SeriesLabels: labels.FromStrings("foo", "bar"),
+		// 			Exemplars: []exemplar.Exemplar{
+		// 				{
+		// 					Labels: labels.FromStrings("trace_id", "abc"),
+		// 					Value:  math.Inf(1),
+		// 					Ts:     1234,
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	expected: `{"status":"success","data":[{"seriesLabels":{"foo":"bar"},"exemplars":[{"labels":{"trace_id":"abc"},"value":"+Inf","timestamp":1.234}]}]}`,
+		// },
 	}
 
-	codec := JSONCodec{}
+	codec := JSONGDFCodec{}
 
 	for _, c := range cases {
 		body, err := codec.Encode(&Response{

--- a/web/api/v1/json_gdf_codec.go
+++ b/web/api/v1/json_gdf_codec.go
@@ -1,0 +1,277 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"unsafe"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/jsonutil"
+)
+
+func init() {
+	//jsoniter.RegisterTypeEncoderFunc("promql.Matrix", marshalGDFMatrixJSON, marshalGDFSeriesJSONIsEmpty)
+	jsoniter.RegisterTypeEncoderFunc("promql.Series", marshalGDFSeriesJSON, marshalGDFSeriesJSONIsEmpty)
+	jsoniter.RegisterTypeEncoderFunc("promql.Sample", marshalGDFSampleJSON, marshalGDFSampleJSONIsEmpty)
+	jsoniter.RegisterTypeEncoderFunc("promql.FPoint", marshalGDFFPointJSON, marshalGDFPointJSONIsEmpty)
+	jsoniter.RegisterTypeEncoderFunc("promql.HPoint", marshalGDFHPointJSON, marshalGDFPointJSONIsEmpty)
+	jsoniter.RegisterTypeEncoderFunc("exemplar.Exemplar", marshalGDFExemplarJSON, marshalExemplarJSONEmpty)
+	jsoniter.RegisterTypeEncoderFunc("labels.Labels", unsafeMarshalLabelsJSON, labelsIsEmpty)
+}
+
+// JSONGDFCodec is a Codec that encodes API responses as JSON.
+type JSONGDFCodec struct{}
+
+func (j JSONGDFCodec) ContentType() MIMEType {
+	return MIMEType{Type: "application", SubType: "json"}
+}
+
+func (j JSONGDFCodec) CanEncode(_ *Response) bool {
+	return true
+}
+
+func (j JSONGDFCodec) Encode(resp *Response) ([]byte, error) {
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	return json.Marshal(resp.Data)
+}
+
+// marshalSeriesJSON writes something like the following:
+//
+//	{
+//	   "metric" : {
+//	      "__name__" : "up",
+//	      "job" : "prometheus",
+//	      "instance" : "localhost:9090"
+//	   },
+//	   "values": [
+//	      [ 1435781451.781, "1" ],
+//	      < more values>
+//	   ],
+//	   "histograms": [
+//	      [ 1435781451.781, { < histogram, see jsonutil.MarshalHistogram > } ],
+//	      < more histograms >
+//	   ],
+//	},
+func marshalGDFSeriesJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	s := *((*promql.Series)(ptr))
+	stream.WriteObjectStart()
+
+	stream.WriteObjectField("schema")
+	stream.WriteObjectStart()
+	func() {
+		stream.WriteObjectField("meta")
+		func() {
+			stream.WriteObjectStart()
+
+			stream.WriteObjectField("type")
+			stream.WriteString("timeseries-multi")
+			stream.WriteMore()
+
+			stream.WriteObjectField("typeVersion")
+			stream.WriteArrayStart()
+			stream.WriteFloat32(0)
+			stream.WriteMore()
+			stream.WriteFloat32(1)
+			stream.WriteArrayEnd()
+
+			stream.WriteObjectEnd()
+		}()
+	}()
+
+	func() {
+		stream.WriteMore()
+		stream.WriteObjectField("fields")
+		stream.WriteArrayStart()
+
+		func() {
+			stream.WriteObjectStart()
+			stream.WriteObjectField("type")
+			stream.WriteString("number")
+			stream.WriteMore()
+			//TODO: typeinfo float64
+			stream.WriteObjectField("labels")
+			marshalLabelsJSON(s.Metric, stream)
+
+			
+
+
+		}()
+
+		stream.WriteArrayEnd()
+	}()
+
+	stream.WriteObjectEnd()
+	stream.WriteObjectEnd()
+
+	// s := *((*promql.Series)(ptr))
+	// stream.WriteObjectStart()
+	// stream.WriteObjectField(`metric`)
+	// marshalLabelsJSON(s.Metric, stream)
+
+	// for i, p := range s.Floats {
+	// 	stream.WriteMore()
+	// 	if i == 0 {
+	// 		stream.WriteObjectField(`values`)
+	// 		stream.WriteArrayStart()
+	// 	}
+	// 	marshalGDFFPointJSON(unsafe.Pointer(&p), stream)
+	// }
+	// if len(s.Floats) > 0 {
+	// 	stream.WriteArrayEnd()
+	// }
+	// for i, p := range s.Histograms {
+	// 	stream.WriteMore()
+	// 	if i == 0 {
+	// 		stream.WriteObjectField(`histograms`)
+	// 		stream.WriteArrayStart()
+	// 	}
+	// 	marshalGDFHPointJSON(unsafe.Pointer(&p), stream)
+	// }
+	// if len(s.Histograms) > 0 {
+	// 	stream.WriteArrayEnd()
+	// }
+	// stream.WriteObjectEnd()
+}
+
+func marshalGDFSeriesJSONIsEmpty(unsafe.Pointer) bool {
+	return false
+}
+
+// marshalGDFSampleJSON writes something like the following for normal value samples:
+//
+//	{
+//	   "metric" : {
+//	      "__name__" : "up",
+//	      "job" : "prometheus",
+//	      "instance" : "localhost:9090"
+//	   },
+//	   "value": [ 1435781451.781, "1.234" ]
+//	},
+//
+// For histogram samples, it writes something like this:
+//
+//	{
+//	   "metric" : {
+//	      "__name__" : "up",
+//	      "job" : "prometheus",
+//	      "instance" : "localhost:9090"
+//	   },
+//	   "histogram": [ 1435781451.781, { < histogram, see jsonutil.MarshalHistogram > } ]
+//	},
+func marshalGDFSampleJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	s := *((*promql.Sample)(ptr))
+	stream.WriteObjectStart()
+	stream.WriteObjectField(`metric`)
+	marshalLabelsJSON(s.Metric, stream)
+	stream.WriteMore()
+	if s.H == nil {
+		stream.WriteObjectField(`value`)
+	} else {
+		stream.WriteObjectField(`histogram`)
+	}
+	stream.WriteArrayStart()
+	jsonutil.MarshalTimestamp(s.T, stream)
+	stream.WriteMore()
+	if s.H == nil {
+		jsonutil.MarshalFloat(s.F, stream)
+	} else {
+		jsonutil.MarshalHistogram(s.H, stream)
+	}
+	stream.WriteArrayEnd()
+	stream.WriteObjectEnd()
+}
+
+func marshalGDFSampleJSONIsEmpty(unsafe.Pointer) bool {
+	return false
+}
+
+// marshalGDFFPointJSON writes `[ts, "1.234"]`.
+func marshalGDFFPointJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	p := *((*promql.FPoint)(ptr))
+	stream.WriteArrayStart()
+	jsonutil.MarshalTimestamp(p.T, stream)
+	stream.WriteMore()
+	jsonutil.MarshalFloat(p.F, stream)
+	stream.WriteArrayEnd()
+}
+
+// marshalGDFHPointJSON writes `[ts, { < histogram, see jsonutil.MarshalHistogram > } ]`.
+func marshalGDFHPointJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	p := *((*promql.HPoint)(ptr))
+	stream.WriteArrayStart()
+	jsonutil.MarshalTimestamp(p.T, stream)
+	stream.WriteMore()
+	jsonutil.MarshalHistogram(p.H, stream)
+	stream.WriteArrayEnd()
+}
+
+func marshalGDFPointJSONIsEmpty(unsafe.Pointer) bool {
+	return false
+}
+
+// marshalExemplarJSON writes.
+//
+//	{
+//	   labels: <labels>,
+//	   value: "<string>",
+//	   timestamp: <float>
+//	}
+func marshalGDFExemplarJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	p := *((*exemplar.Exemplar)(ptr))
+	stream.WriteObjectStart()
+
+	// "labels" key.
+	stream.WriteObjectField(`labels`)
+	marshalLabelsJSON(p.Labels, stream)
+
+	// "value" key.
+	stream.WriteMore()
+	stream.WriteObjectField(`value`)
+	jsonutil.MarshalFloat(p.Value, stream)
+
+	// "timestamp" key.
+	stream.WriteMore()
+	stream.WriteObjectField(`timestamp`)
+	jsonutil.MarshalTimestamp(p.Ts, stream)
+
+	stream.WriteObjectEnd()
+}
+
+func marshalGDFExemplarJSONEmpty(unsafe.Pointer) bool {
+	return false
+}
+
+func unsafeMarshalGDFLabelsJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
+	labelsPtr := (*labels.Labels)(ptr)
+	marshalLabelsJSON(*labelsPtr, stream)
+}
+
+func marshalGDFLabelsJSON(lbls labels.Labels, stream *jsoniter.Stream) {
+	stream.WriteObjectStart()
+	i := 0
+	lbls.Range(func(v labels.Label) {
+		if i != 0 {
+			stream.WriteMore()
+		}
+		i++
+		stream.WriteString(v.Name)
+		stream.WriteRaw(`:`)
+		stream.WriteString(v.Value)
+	})
+	stream.WriteObjectEnd()
+}

--- a/web/api/v1/json_gdf_codec.go
+++ b/web/api/v1/json_gdf_codec.go
@@ -101,21 +101,66 @@ func marshalGDFSeriesJSON(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		func() {
 			stream.WriteObjectStart()
 			stream.WriteObjectField("type")
+			stream.WriteString("time")
+			//TODO: typeinfo time
+			stream.WriteObjectEnd()
+
+			stream.WriteMore()
+
+			stream.WriteObjectStart()
+			stream.WriteObjectField("type")
 			stream.WriteString("number")
 			stream.WriteMore()
 			//TODO: typeinfo float64
 			stream.WriteObjectField("labels")
 			marshalLabelsJSON(s.Metric, stream)
-
-			
-
-
+			stream.WriteObjectEnd()
 		}()
-
 		stream.WriteArrayEnd()
 	}()
 
-	stream.WriteObjectEnd()
+	stream.WriteObjectEnd() // End Schema
+
+	stream.WriteMore()
+
+	stream.WriteObjectField("data")
+	func() {
+		stream.WriteObjectStart()
+		ts := make([]int64, len(s.Floats))
+		vals := make([]float64, len(s.Floats))
+		for i, p := range s.Floats {
+			ts[i] = p.T
+			vals[i] = p.F
+		}
+
+		stream.WriteObjectField("values")
+		stream.WriteArrayStart()
+
+		stream.WriteArrayStart()
+		for i, t := range ts {
+			stream.WriteInt64(t)
+			if i == len(ts)-1 {
+				continue
+			}
+			stream.WriteMore()
+		}
+		stream.WriteArrayEnd()
+		
+		stream.WriteMore()
+		stream.WriteArrayStart()
+		for i, f := range vals {
+			stream.WriteFloat64(f)
+			if i == len(vals)-1 {
+				continue
+			}
+			stream.WriteMore()
+		}
+		stream.WriteArrayEnd()
+
+		stream.WriteArrayEnd()
+		stream.WriteObjectEnd()
+	}()
+
 	stream.WriteObjectEnd()
 
 	// s := *((*promql.Series)(ptr))


### PR DESCRIPTION
Explore returning Grafana dataframes directly from prometheus. Would be different endpoints of course, but currently just hacking and overriding things to explore a little.


```
$ curl  --url http://localhost:9095/api/v1/query_range\?query\=vector\(1\)\&start=2015-07-01T20:10:30.781Z\&end=2015-07-01T20:11:00.781Z\&step\=15s | jq
```
```json
{
  "Err": null,
  "Value": [
    {
      "schema": {
        "meta": {
          "type": "timeseries-multi",
          "typeVersion": [
            0,
            1
          ]
        },
        "fields": [
          {
            "type": "time"
          },
          {
            "type": "number",
            "labels": {}
          }
        ]
      },
      "data": {
        "values": [
          [
            1435781430781,
            1435781445781,
            1435781460781
          ],
          [
            1,
            1,
            1
          ]
        ]
      }
    }
  ],
  "Warnings": null
}
```